### PR TITLE
Fix wheel speed formula: add div=16 for DA18 2B1B-2B1E

### DIFF
--- a/signalsets/v3/default.json
+++ b/signalsets/v3/default.json
@@ -190,19 +190,19 @@
   ]},
 { "hdr": "DA18", "rax": "18", "cmd": {"22": "2B1B"}, "freq": 1, "dbgfilter": { "to": 2018, "from": 2020 },
   "signals": [
-    {"id": "RENEGADE_WSS_RR", "path": "Movement", "fmt": { "len": 16, "max": 300, "unit": "kilometersPerHour" }, "name": "Rear right wheel speed"}
+    {"id": "RENEGADE_WSS_RR", "path": "Movement", "fmt": { "len": 16, "max": 300, "div": 16, "unit": "kilometersPerHour" }, "name": "Rear right wheel speed"}
   ]},
 { "hdr": "DA18", "rax": "18", "cmd": {"22": "2B1C"}, "freq": 1, "dbgfilter": { "to": 2018, "from": 2020 },
   "signals": [
-    {"id": "RENEGADE_WSS_RL", "path": "Movement", "fmt": { "len": 16, "max": 300, "unit": "kilometersPerHour" }, "name": "Rear left wheel speed"}
+    {"id": "RENEGADE_WSS_RL", "path": "Movement", "fmt": { "len": 16, "max": 300, "div": 16, "unit": "kilometersPerHour" }, "name": "Rear left wheel speed"}
   ]},
 { "hdr": "DA18", "rax": "18", "cmd": {"22": "2B1D"}, "freq": 1, "dbgfilter": { "to": 2018, "from": 2020 },
   "signals": [
-    {"id": "RENEGADE_WSS_FR", "path": "Movement", "fmt": { "len": 16, "max": 300, "unit": "kilometersPerHour" }, "name": "Front right wheel speed"}
+    {"id": "RENEGADE_WSS_FR", "path": "Movement", "fmt": { "len": 16, "max": 300, "div": 16, "unit": "kilometersPerHour" }, "name": "Front right wheel speed"}
   ]},
 { "hdr": "DA18", "rax": "18", "cmd": {"22": "2B1E"}, "freq": 1, "dbgfilter": { "to": 2018, "from": 2020 },
   "signals": [
-    {"id": "RENEGADE_WSS_FL", "path": "Movement", "fmt": { "len": 16, "max": 300, "unit": "kilometersPerHour" }, "name": "Front left wheel speed"}
+    {"id": "RENEGADE_WSS_FL", "path": "Movement", "fmt": { "len": 16, "max": 300, "div": 16, "unit": "kilometersPerHour" }, "name": "Front left wheel speed"}
   ]},
 { "hdr": "DA18", "rax": "18", "cmd": {"22": "F158"}, "freq": 86400, "dbgfilter": { "to": 2014, "years": [2016, 2017, 2020], "from": 2022 },
   "signals": [

--- a/tests/test_cases/2019/commands/DA18.18.222B1B.yaml
+++ b/tests/test_cases/2019/commands/DA18.18.222B1B.yaml
@@ -4,8 +4,9 @@ test_cases:
     RENEGADE_WSS_RR: 0
   response: 18DAF11805622B1B0000
 - expected_values:
-    RENEGADE_WSS_RR: 300
+    RENEGADE_WSS_RR: 95.9375
   response: 18DAF11805622B1B05FF
 - expected_values:
-    RENEGADE_WSS_RR: 300
+    RENEGADE_WSS_RR: 96
   response: 18DAF11805622B1B0600
+

--- a/tests/test_cases/2019/commands/DA18.18.222B1C.yaml
+++ b/tests/test_cases/2019/commands/DA18.18.222B1C.yaml
@@ -4,8 +4,9 @@ test_cases:
     RENEGADE_WSS_RL: 0
   response: 18DAF11805622B1C0000
 - expected_values:
-    RENEGADE_WSS_RL: 300
+    RENEGADE_WSS_RL: 95.9375
   response: 18DAF11805622B1C05FF
 - expected_values:
-    RENEGADE_WSS_RL: 300
+    RENEGADE_WSS_RL: 96.1875
   response: 18DAF11805622B1C0603
+

--- a/tests/test_cases/2019/commands/DA18.18.222B1D.yaml
+++ b/tests/test_cases/2019/commands/DA18.18.222B1D.yaml
@@ -4,8 +4,9 @@ test_cases:
     RENEGADE_WSS_FR: 0
   response: 18DAF11805622B1D0000
 - expected_values:
-    RENEGADE_WSS_FR: 300
+    RENEGADE_WSS_FR: 95.875
   response: 18DAF11805622B1D05FE
 - expected_values:
-    RENEGADE_WSS_FR: 300
+    RENEGADE_WSS_FR: 96
   response: 18DAF11805622B1D0600
+

--- a/tests/test_cases/2019/commands/DA18.18.222B1E.yaml
+++ b/tests/test_cases/2019/commands/DA18.18.222B1E.yaml
@@ -4,8 +4,9 @@ test_cases:
     RENEGADE_WSS_FL: 0
   response: 18DAF11805622B1E0000
 - expected_values:
-    RENEGADE_WSS_FL: 300
+    RENEGADE_WSS_FL: 79.875
   response: 18DAF11805622B1E04FE
 - expected_values:
-    RENEGADE_WSS_FL: 300
+    RENEGADE_WSS_FL: 96
   response: 18DAF11805622B1E0600
+


### PR DESCRIPTION
## Summary

- Add missing `div: 16` to wheel speed DIDs 2B1B, 2B1C, 2B1D, 2B1E (DA18 header)
- Without this divisor, displayed speed is **16x the actual value** (e.g. 1600 km/h instead of 100 km/h)
- Formula confirmed via AlfaOBD reverse-engineering sessions and cross-referenced with vdiag formula auditor

## Details

The wheel speed raw value from the ZF 9HP48 TCM uses the encoding `raw/16` to get km/h. This was documented in our [correction notes](https://github.com/OBDb/Jeep-Renegade/pull/115) but the DA18 commands were not included in that PR (which only fixed DA10 formulas).

## Test plan

- [x] Formula auditor confirms `div=16` matches known AlfaOBD values
- [x] Test value: raw `0x0640` → `100.0 km/h` (verified in highway collection data)
- [ ] Pelican scan session with corrected signalset

🤖 Generated with [Claude Code](https://claude.com/claude-code)